### PR TITLE
Add version 0.13.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -58,14 +58,8 @@ let
             installPhase = ''
               export HOME=$TMP
 
-              ${self.lib.optionalString self.stdenv.isLinux ''
-              local LD_LINUX_SO=$(ldd $(which iconv)|grep ld-linux-x86|cut -d' ' -f3)
-              local IS_STATIC=$(ldd ./dfx | grep 'not a dynamic executable')
-              local USE_LIB64=$(ldd ./dfx | grep '/lib64/ld-linux-x86-64.so.2')
               chmod +rw ./dfx
-              test -n "$IS_STATIC" || test -z "$USE_LIB64" || patchelf --set-interpreter "$LD_LINUX_SO" ./dfx
-              ''}
-
+              autoPatchelf .
               ./dfx cache install
 
               local CACHE_DIR="$out/.cache/dfinity/versions/${version}"

--- a/default.nix
+++ b/default.nix
@@ -139,7 +139,7 @@ let
         version = "0.9.2";
       };
 
-      sdk-0_13_1 = makeVersion {
+      sdk-0_14_3 = makeVersion {
         systems = {
           "x86_64-darwin" = {
             sha256 = self.lib.fakeSha256;
@@ -147,20 +147,20 @@ let
           };
           "x86_64-linux" = {
             # sha256 = self.lib.fakeSha256;
-            sha256 = "sha256-JQ1BKzqO291oZ5W8LCcbb4VTTStESV3WCMZwOby251Y=";
+            sha256 = "sha256-ERea1jlbA2JtiLf+YvtIPnPf7yLPH3r6dWVoYc2vBhg=";
           };
         };
-        version = "0.13.1";
+        version = "0.14.3";
       };
 
       # https://sdk.dfinity.org/manifest.json
       versions = {
-        latest = sdk-0_13_1;
+        latest = sdk-0_14_3;
         "0.6.21" = sdk-0_6_21;
         "0.7.0-beta.8" = sdk-0_7_0-beta_8;
         "0.8.4" = sdk-0_8_4;
         "0.9.2" = sdk-0_9_2;
-        "0.13.1" = sdk-0_13_1;
+        "0.14.3" = sdk-0_14_3;
       };
     in
       versions // { inherit makeVersion; }

--- a/default.nix
+++ b/default.nix
@@ -133,7 +133,7 @@ let
         version = "0.9.2";
       };
 
-      sdk-0_14_4 = makeVersion {
+      sdk-0_15_0 = makeVersion {
         systems = {
           "x86_64-darwin" = {
             sha256 = self.lib.fakeSha256;
@@ -141,20 +141,20 @@ let
           };
           "x86_64-linux" = {
             # sha256 = self.lib.fakeSha256;
-            sha256 = "sha256-l48yDQ8EEpcloQh0KH88LJe5WEyAPL2Y5eWcV0qOwB0=";
+            sha256 = "sha256-P24J31kL9eNEtiDpegGatLdMtnj2otxrKRddWEXe7kc=";
           };
         };
-        version = "0.14.4";
+        version = "0.15.0";
       };
 
       # https://sdk.dfinity.org/manifest.json
       versions = {
-        latest = sdk-0_14_4;
+        latest = sdk-0_15_0;
         "0.6.21" = sdk-0_6_21;
         "0.7.0-beta.8" = sdk-0_7_0-beta_8;
         "0.8.4" = sdk-0_8_4;
         "0.9.2" = sdk-0_9_2;
-        "0.14.4" = sdk-0_14_4;
+        "0.15.0" = sdk-0_15_0;
       };
     in
       versions // { inherit makeVersion; }

--- a/default.nix
+++ b/default.nix
@@ -133,7 +133,7 @@ let
         version = "0.9.2";
       };
 
-      sdk-0_14_3 = makeVersion {
+      sdk-0_14_4 = makeVersion {
         systems = {
           "x86_64-darwin" = {
             sha256 = self.lib.fakeSha256;
@@ -141,20 +141,20 @@ let
           };
           "x86_64-linux" = {
             # sha256 = self.lib.fakeSha256;
-            sha256 = "sha256-ERea1jlbA2JtiLf+YvtIPnPf7yLPH3r6dWVoYc2vBhg=";
+            sha256 = "sha256-l48yDQ8EEpcloQh0KH88LJe5WEyAPL2Y5eWcV0qOwB0=";
           };
         };
-        version = "0.14.3";
+        version = "0.14.4";
       };
 
       # https://sdk.dfinity.org/manifest.json
       versions = {
-        latest = sdk-0_14_3;
+        latest = sdk-0_14_4;
         "0.6.21" = sdk-0_6_21;
         "0.7.0-beta.8" = sdk-0_7_0-beta_8;
         "0.8.4" = sdk-0_8_4;
         "0.9.2" = sdk-0_9_2;
-        "0.14.3" = sdk-0_14_3;
+        "0.14.4" = sdk-0_14_4;
       };
     in
       versions // { inherit makeVersion; }

--- a/default.nix
+++ b/default.nix
@@ -140,13 +140,28 @@ let
         version = "0.9.2";
       };
 
+      sdk-0_13_1 = makeVersion {
+        systems = {
+          "x86_64-darwin" = {
+            sha256 = self.lib.fakeSha256;
+            # sha256 = "UITKzQ9Xzlsy00DU72Ah2VH8736eQeW8GL6hzJHTaYA=";
+          };
+          "x86_64-linux" = {
+            # sha256 = self.lib.fakeSha256;
+            sha256 = "sha256-JQ1BKzqO291oZ5W8LCcbb4VTTStESV3WCMZwOby251Y=";
+          };
+        };
+        version = "0.13.1";
+      };
+
       # https://sdk.dfinity.org/manifest.json
       versions = {
-        latest = sdk-0_8_4;
+        latest = sdk-0_13_1;
         "0.6.21" = sdk-0_6_21;
         "0.7.0-beta.8" = sdk-0_7_0-beta_8;
         "0.8.4" = sdk-0_8_4;
         "0.9.2" = sdk-0_9_2;
+        "0.13.1" = sdk-0_13_1;
       };
     in
       versions // { inherit makeVersion; }

--- a/default.nix
+++ b/default.nix
@@ -81,7 +81,7 @@ let
                 ln -s $CACHE_DIR/$binary $out/bin/$binary
               done
 
-              wrapProgram $CACHE_DIR/dfx --set DFX_CONFIG_ROOT $out
+              wrapProgram $CACHE_DIR/dfx --set DFX_CACHE_ROOT $out
               rm $out/bin/dfx
               ln -s $CACHE_DIR/dfx $out/bin/dfx
             '';

--- a/default.nix
+++ b/default.nix
@@ -47,6 +47,11 @@ let
               self.glibc.bin
               self.patchelf
               self.which
+              self.autoPatchelfHook
+            ];
+            buildInputs = [
+              self.stdenv.cc.cc.lib
+              self.libunwind
             ];
             # Use `find $(dfx cache show) -type f -executable -print` on macOS to
             # help discover what to symlink.
@@ -69,15 +74,9 @@ let
 
               mkdir -p $out/bin
 
-              for binary in dfx ic-ref ic-starter icx-proxy mo-doc mo-ide moc replica; do
-                ${self.lib.optionalString self.stdenv.isLinux ''
-                local BINARY="$CACHE_DIR/$binary"
-                test -f "$BINARY" || continue
-                local IS_STATIC=$(ldd "$BINARY" | grep 'not a dynamic executable')
-                local USE_LIB64=$(ldd "$BINARY" | grep '/lib64/ld-linux-x86-64.so.2')
-                chmod +rw "$BINARY"
-                test -n "$IS_STATIC" || test -z "$USE_LIB64" || patchelf --set-interpreter "$LD_LINUX_SO" "$BINARY"
-                ''}
+              addAutoPatchelfSearchPath $CACHE_DIR
+
+              for binary in dfx ic-ref ic-starter icx-proxy mo-doc mo-ide moc replica ; do
                 ln -s $CACHE_DIR/$binary $out/bin/$binary
               done
 

--- a/examples/flake/flake.lock
+++ b/examples/flake/flake.lock
@@ -3,12 +3,13 @@
     "dfinity-sdk": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-zyABLkjsQG10ggHjgsLFczjM2tAMOrB7OsPRhUlCJlw=",
-        "path": "/nix/store/982fn4524aqcwhd55jw0yhqv6nk3ssa1-source",
+        "lastModified": 0,
+        "narHash": "sha256-2dCMlzjebld3yrNXJ5uCN67/eOKSHt2OcUk1GA9jp5o=",
+        "path": "/nix/store/kpr5bi9id79vybvpfrdl31q759x3a8jw-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/982fn4524aqcwhd55jw0yhqv6nk3ssa1-source",
+        "path": "/nix/store/kpr5bi9id79vybvpfrdl31q759x3a8jw-source",
         "type": "path"
       }
     },


### PR DESCRIPTION
Also fixes #4, and uses the simpler `autoPatchElfHook`.

Not done:

 * Test on OSX, and update hash
 * Test old versions, and/or keep old logic around (why even bother with old versions?)